### PR TITLE
ADDED | extend and allOf functionality

### DIFF
--- a/consumers/jsdocInfo.js
+++ b/consumers/jsdocInfo.js
@@ -1,17 +1,37 @@
 const doctrine = require('doctrine');
 
+const convertTagToAllOfUnionType = tag => {
+  const elementsToCombine = tag.type.name.split('&').map(t => ({ type: 'NameExpression', name: t }));
+  const elements = [{ type: 'NameExpression', name: 'allOf' }, ...elementsToCombine];
+  const tagType = {
+    type: 'UnionType',
+    elements,
+  };
+  const modifiedTag = JSON.parse(JSON.stringify(tag));
+  modifiedTag.type = tagType;
+  return modifiedTag;
+};
+
 const jsdocInfo = (options = { unwrap: true }) => comments => {
   if (!comments || !Array.isArray(comments)) return [];
   return comments.map(comment => {
-    const parsedValue = doctrine.parse(comment, options);
+    let modifiedComment = comment;
+    if (comment.includes('@extends')) {
+      const itemsToExtend = comment.match(/(@extends\s{[\s\S]*?})/g).map(i => i.replace('@extends {', '').replace('}', ''));
+      modifiedComment = comment
+        .replace(/@typedef\s{object/g, `@typedef {allOf|${itemsToExtend.join('|')}`)
+        .replace(/(@extends\s{[\s\S]*?})/g, '');
+    }
+    const parsedValue = doctrine.parse(modifiedComment, options);
     const tags = parsedValue.tags.map(tag => ({
       ...tag,
       description: tag.description ? tag.description.replace('\n/', '').replace(/\/$/, '') : tag.description,
     }));
+    const tagsSupportingAllOfUnionType = tags.map(t => (!t.type?.name?.includes('&') ? t : convertTagToAllOfUnionType(t)));
     const description = parsedValue.description.replace('/**\n', '').replace('\n/', '');
     return {
       ...parsedValue,
-      tags,
+      tags: tagsSupportingAllOfUnionType,
       description,
     };
   });

--- a/index.js
+++ b/index.js
@@ -38,7 +38,19 @@ const expressJSDocSwagger = app => (userOptions = {}, userSwagger = {}) => {
         ...swaggerObject,
         host: req.get('host'),
       };
-      req.swaggerDoc = swaggerObject;
+      // The below is a change to the order of the swagger output to put 'paths' before 'components'.
+      // This is to fix a bug where 'allOf' properties were not displaying correctly in the 'example value'.
+      // This is a known swagger-ui bug, where the suggested fix is to make sure paths appears before components.
+      // Reference links below:
+      // - https://github.com/swagger-api/swagger-ui/issues/5972
+      // - https://github.com/swagger-api/swagger-js/issues/1394
+      // - https://github.com/swagger-api/swagger-editor/issues/2765
+      const objectOrder = {
+        paths: null,
+        components: null,
+      };
+      const modifiedOrderObject = Object.assign(objectOrder, swaggerObject);
+      req.swaggerDoc = modifiedOrderObject;
       next();
     }, swaggerUi.serve, swaggerUi.setup(undefined, options.swaggerUiOptions));
   }

--- a/test/transforms/components/index.test.js
+++ b/test/transforms/components/index.test.js
@@ -267,7 +267,7 @@ describe('parseComponents method', () => {
        * @property {number=} year - The year - int64
        */
     `,
-    `
+      `
       /**
        * Album
        * @typedef {object} Album
@@ -335,7 +335,7 @@ describe('parseComponents method', () => {
        * @property {number=} year - The year - int64
        */
     `,
-    `
+      `
       /**
        * Album
        * @typedef {object} Album
@@ -395,7 +395,7 @@ describe('parseComponents method', () => {
        * @property {number=} year
        */
     `,
-    `
+      `
       /**
        * Album
        * @typedef {object} Album
@@ -454,7 +454,7 @@ describe('parseComponents method', () => {
        * @property {number=} year - The year - int64
        */
     `,
-    `
+      `
       /**
        * Author model
        * @typedef {object} Author
@@ -462,7 +462,7 @@ describe('parseComponents method', () => {
        * @property {number=} age - Author age - int64
        */
     `,
-    `
+      `
       /**
        * Album
        * @typedef {object} Album
@@ -733,6 +733,74 @@ describe('parseComponents method', () => {
     expect(result).toEqual(expected);
   });
 
+  it('Should parse a SingleAlbum schema which extends the reference of Song.', () => {
+    const jsodInput = [`
+        /**
+         * A song
+         * @typedef {object} Song
+         * @property {string} title.required - The title
+         * @property {string=} artist - The artist
+         * @property {number=} year - The year - int64
+         */
+      `, `
+      /**
+       * SingleAlbum
+       * @typedef {object} SingleAlbum
+       * @extends {Song}
+       * @property {array<string>=} songs - songs array
+       */
+    `];
+    const expected = {
+      components: {
+        schemas: {
+          SingleAlbum: {
+            allOf: [
+              {
+                $ref: '#/components/schemas/Song',
+              },
+            ],
+            type: 'object',
+            description: 'SingleAlbum',
+            properties: {
+              songs: {
+                type: 'array',
+                description: 'songs array',
+                items: {
+                  type: 'string',
+                },
+              },
+            },
+          },
+          Song: {
+            type: 'object',
+            required: [
+              'title',
+            ],
+            description: 'A song',
+            properties: {
+              title: {
+                type: 'string',
+                description: 'The title',
+              },
+              artist: {
+                type: 'string',
+                description: 'The artist',
+              },
+              year: {
+                type: 'number',
+                description: 'The year',
+                format: 'int64',
+              },
+            },
+          },
+        },
+      },
+    };
+    const parsedJSDocs = jsdocInfo()(jsodInput);
+    const result = parseComponents({}, parsedJSDocs);
+    expect(result).toEqual(expected);
+  });
+
   it('Should parse a SongOrAlbum schema with oneOf reference of Song and Album.', () => {
     const jsodInput = [`
       /**
@@ -875,7 +943,7 @@ describe('parseComponents method', () => {
         * @property {string=} email
         */
       `,
-    `
+      `
        /**
         * Profiles dict
         * @typedef {Dictionary<Profile>} Profiles

--- a/test/transforms/paths/combineSchemas.test.js
+++ b/test/transforms/paths/combineSchemas.test.js
@@ -157,6 +157,49 @@ test('should parse jsdoc path reference params with allOf keyword', () => {
   expect(result).toEqual(expected);
 });
 
+test('should parse jsdoc path reference params as allOf using ampersand', () => {
+  const jsodInput = [`
+    /**
+     * GET /api/v1
+     * @param {Song&Album} name.query.required - name param description
+     */
+  `];
+  const expected = {
+    paths: {
+      '/api/v1': {
+        get: {
+          deprecated: false,
+          description: undefined,
+          summary: '',
+          responses: {},
+          security: [],
+          tags: [],
+          parameters: [{
+            deprecated: false,
+            description: 'name param description',
+            in: 'query',
+            name: 'name',
+            required: true,
+            schema: {
+              allOf: [
+                {
+                  $ref: '#/components/schemas/Song',
+                },
+                {
+                  $ref: '#/components/schemas/Album',
+                },
+              ],
+            },
+          }],
+        },
+      },
+    },
+  };
+  const parsedJSDocs = jsdocInfo()(jsodInput);
+  const result = setPaths({}, parsedJSDocs);
+  expect(result).toEqual(expected);
+});
+
 test('should parse component with anyOf array keyword', () => {
   const jsodInput = [`
     /**


### PR DESCRIPTION
### What kind of change does this PR introduce? (check at least one)
 - [X] Bugfix
 - [X] Feature
 - [X] Test
 - [ ] Docs
 - [ ] Refactor
 - [ ] Build-related changes
 - [ ] Other, please describe:

### Description:
- added @extends support
- added test for @extends
- fixed display of allOf parameter in swagger ui output

![image](https://github.com/adaptemy-repo/express-jsdoc-swagger-adaptemy/assets/12222835/4eb9c96f-223c-4c63-afda-2c7c00c720a2)

![image](https://github.com/adaptemy-repo/express-jsdoc-swagger-adaptemy/assets/12222835/23cb9b56-81ed-4d6d-90f3-21d795359a65)

showing the ampersand model for curriculum
![image](https://github.com/adaptemy-repo/express-jsdoc-swagger-adaptemy/assets/12222835/909c4e2d-c3a6-4dd7-bd83-0fa765d2b5f7)
