### PR TITLE
Feat/multiple client support

### DIFF
--- a/consumers/jsdocInfo.js
+++ b/consumers/jsdocInfo.js
@@ -14,7 +14,15 @@ const convertTagToAllOfUnionType = tag => {
 
 const jsdocInfo = (options = { unwrap: true }) => comments => {
   if (!comments || !Array.isArray(comments)) return [];
-  return comments.map(comment => {
+  return comments.filter(comment => {
+    // Remove client specific functions if the current client does not match one of the listed clients
+    let clients = [];
+    if (comment.includes('@clients')) {
+      const parsedValue = doctrine.parse(comment, options);
+      clients = parsedValue.tags.find(tag => tag.title === 'clients').description.split('|').map(t => t.trim());
+    }
+    return !comment.includes('@clients') || (comment.includes('@clients') && (clients.some(c => c === options.client)));
+  }).map(comment => {
     let modifiedComment = comment;
     if (comment.includes(' & ') && !comment.includes('BasicAuth & BearerAuth')) { // TODO: fix this hacky exclusion of 'BasicAuth & BearerAuth'
       modifiedComment = comment.replaceAll(/\s&\s/g, '&');

--- a/index.js
+++ b/index.js
@@ -56,7 +56,11 @@ const expressJSDocSwagger = app => (userOptions = {}, userSwagger = {}) => {
       };
       req.swaggerDoc = modifiedOrderObject;
       next();
-    }, swaggerUi.serve, swaggerUi.setup(undefined, options.swaggerUiOptions));
+    // }, swaggerUi.serve, swaggerUi.setup(undefined, options.swaggerUiOptions));
+    }, swaggerUi.serve, swaggerUi.setup(
+      undefined,
+      options.swaggerUiOptions,
+    ));
   }
 
   if (options.exposeApiDocs) {

--- a/processSwagger.js
+++ b/processSwagger.js
@@ -28,7 +28,7 @@ const processSwagger = (options, logger = defaultLogger) => {
   return globFilesMatches(options.baseDir, options.filesPattern)
     .then(readFiles)
     .then(getOnlyComments)
-    .then(jsdocInfo())
+    .then(jsdocInfo({ client: options.client, unwrap: true }))
     .then(data => {
       swaggerObject = getPaths(swaggerObject, data);
       logger({ entity: 'paths', swaggerObject });

--- a/test/transforms/components/index.test.js
+++ b/test/transforms/components/index.test.js
@@ -214,6 +214,54 @@ describe('parseComponents method', () => {
     expect(result).toEqual(expected);
   });
 
+  // TODO: add the functionality to make this test pass
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('Should parse jsdoc component spec with non-standard property name', () => {
+    const jsodInput = [`
+      /**
+       * A song
+       * @typedef {object} Song
+       * @property {{'en-US': string - Some description US, 'en-UK': string - Some description UK}}
+       * @property {string=} artist - The artist - json:{"maxLength": 300}
+       * @property {number=} year - The year - int64 - json:{"minimum": 2000}
+       */
+    `];
+    const expected = {
+      components: {
+        schemas: {
+          Song: {
+            type: 'object',
+            description: 'A song',
+            properties: {
+              'en-US': {
+                type: 'string',
+                description: 'Some description US',
+              },
+              'en-UK': {
+                type: 'string',
+                description: 'Some description UK',
+              },
+              artist: {
+                type: 'string',
+                description: 'The artist',
+                maxLength: 300,
+              },
+              year: {
+                type: 'number',
+                description: 'The year',
+                format: 'int64',
+                minimum: 2000,
+              },
+            },
+          },
+        },
+      },
+    };
+    const parsedJSDocs = jsdocInfo()(jsodInput);
+    const result = parseComponents({}, parsedJSDocs);
+    expect(result).toEqual(expected);
+  });
+
   it('Should parse jsdoc component spec with require and format properties', () => {
     const jsodInput = [`
       /**
@@ -267,7 +315,7 @@ describe('parseComponents method', () => {
        * @property {number=} year - The year - int64
        */
     `,
-      `
+    `
       /**
        * Album
        * @typedef {object} Album
@@ -335,7 +383,7 @@ describe('parseComponents method', () => {
        * @property {number=} year - The year - int64
        */
     `,
-      `
+    `
       /**
        * Album
        * @typedef {object} Album
@@ -395,7 +443,7 @@ describe('parseComponents method', () => {
        * @property {number=} year
        */
     `,
-      `
+    `
       /**
        * Album
        * @typedef {object} Album
@@ -454,7 +502,7 @@ describe('parseComponents method', () => {
        * @property {number=} year - The year - int64
        */
     `,
-      `
+    `
       /**
        * Author model
        * @typedef {object} Author
@@ -462,7 +510,7 @@ describe('parseComponents method', () => {
        * @property {number=} age - Author age - int64
        */
     `,
-      `
+    `
       /**
        * Album
        * @typedef {object} Album
@@ -943,7 +991,7 @@ describe('parseComponents method', () => {
         * @property {string=} email
         */
       `,
-      `
+    `
        /**
         * Profiles dict
         * @typedef {Dictionary<Profile>} Profiles

--- a/test/transforms/paths/clients.test.js
+++ b/test/transforms/paths/clients.test.js
@@ -1,0 +1,50 @@
+const jsdocInfo = require('../../../consumers/jsdocInfo');
+const setPaths = require('../../../transforms/paths');
+
+describe('Paths - clients', () => {
+  it('Should return docs if client is specified and current client matches any of the listed clients', () => {
+    const jsodInput = [`
+      /**
+       * GET /api/v1
+       * @clients bbc | internal
+       * @tags album
+       */
+    `];
+    const expected = {
+      paths: {
+        '/api/v1': {
+          get: {
+            deprecated: false,
+            description: undefined,
+            summary: '',
+            tags: [
+              'album',
+            ],
+            responses: {},
+            parameters: [],
+            security: [],
+          },
+        },
+      },
+    };
+    const parsedJSDocs = jsdocInfo({ client: 'bbc', unwrap: true })(jsodInput);
+    const result = setPaths({}, parsedJSDocs);
+    expect(result).toEqual(expected);
+  });
+
+  it('Should not return docs if client is specified and current client is not a match', () => {
+    const jsodInput = [`
+      /**
+       * GET /api/v1
+       * @clients folens
+       * @tags album
+       */
+    `];
+    const expected = {
+      paths: {},
+    };
+    const parsedJSDocs = jsdocInfo({ client: 'bbc', unwrap: true })(jsodInput);
+    const result = setPaths({}, parsedJSDocs);
+    expect(result).toEqual(expected);
+  });
+});

--- a/transforms/components/index.js
+++ b/transforms/components/index.js
@@ -43,7 +43,7 @@ const addTypeApplication = (applications, expression) => {
     };
   }
   // eslint-disable-next-line no-console
-  console.error('Unhandled swagger type encountered, notify aimee/renaldas if you see this warning.');
+  console.error('Unhandled swagger type encountered, notify aimee if you see this warning.');
   return {};
 };
 


### PR DESCRIPTION
### What kind of change does this PR introduce? (check at least one)
 - [ ] Bugfix
 - [X] Feature
 - [X] Test
 - [ ] Docs
 - [ ] Refactor
 - [ ] Build-related changes
 - [ ] Other, please describe:

### Description:
- added support for splitting clients so if a client is specified on an endpoint, it will only appear on documentation for that client

![image](https://github.com/user-attachments/assets/0e0d558f-c1b8-40f7-93b4-eeb339cf4b04)
