### PR TITLE
ADDED | support for client specific properties

### DIFF
--- a/test/transforms/components/index.test.js
+++ b/test/transforms/components/index.test.js
@@ -172,6 +172,82 @@ describe('parseComponents method', () => {
     expect(result).toEqual(expected);
   });
 
+  it('Should return client specific property when client specified matches', () => {
+    const jsodInput = [`
+      /**
+       * A song
+       * @typedef {object} Song
+       * @property {string=} title - The title
+       * @property {string=} artist - The artist - clients:generic,hecof
+       * @property {number=} year - The year - int64
+       */
+    `];
+    const expected = {
+      components: {
+        schemas: {
+          Song: {
+            type: 'object',
+            description: 'A song',
+            properties: {
+              title: {
+                type: 'string',
+                description: 'The title',
+              },
+              artist: {
+                type: 'string',
+                description: 'The artist',
+              },
+              year: {
+                type: 'number',
+                description: 'The year',
+                format: 'int64',
+              },
+            },
+          },
+        },
+      },
+    };
+    const parsedJSDocs = jsdocInfo({ client: 'generic', unwrap: true })(jsodInput);
+    const result = parseComponents(undefined, parsedJSDocs, { client: 'generic' });
+    expect(result).toEqual(expected);
+  });
+
+  it('Should not client specific property when client specified does not match', () => {
+    const jsodInput = [`
+      /**
+       * A song
+       * @typedef {object} Song
+       * @property {string=} title - The title
+       * @property {string=} artist - The artist - clients:generic,hecof
+       * @property {number=} year - The year - int64
+       */
+    `];
+    const expected = {
+      components: {
+        schemas: {
+          Song: {
+            type: 'object',
+            description: 'A song',
+            properties: {
+              title: {
+                type: 'string',
+                description: 'The title',
+              },
+              year: {
+                type: 'number',
+                description: 'The year',
+                format: 'int64',
+              },
+            },
+          },
+        },
+      },
+    };
+    const parsedJSDocs = jsdocInfo({ client: 'bbc', unwrap: true })(jsodInput);
+    const result = parseComponents(undefined, parsedJSDocs, { client: 'bbc' });
+    expect(result).toEqual(expected);
+  });
+
   it('Should parse jsdoc component spec with json options', () => {
     const jsodInput = [`
       /**

--- a/transforms/components/index.js
+++ b/transforms/components/index.js
@@ -2,6 +2,7 @@ const { getTagInfo, getTagsInfo } = require('../utils/tags');
 const mapDescription = require('../utils/mapDescription');
 const { refSchema, formatRefSchema } = require('../utils/refSchema');
 const addEnumValues = require('../utils/enumValues');
+const { addClientValues, hasClientProperty, removePropertyByClient } = require('../utils/clientPropertyMethods');
 const formatDescription = require('../utils/formatDescription');
 const combineSchema = require('../utils/combineSchema');
 const validateTypes = require('../utils/validateTypes');
@@ -61,7 +62,7 @@ const formatProperties = (properties, options = {}) => {
       name: typeName, applications, expression, elements,
     } = property.type;
     const propertyExpression = property.type?.type === 'OptionalType' ? property.type?.expression : expression;
-    const [descriptionValue, enumValues, jsonOptions] = formatDescription(property.description);
+    const [descriptionValue, enumValues, clientValues, jsonOptions] = formatDescription(property.description);
     const [description, format] = mapDescription(descriptionValue);
     return {
       ...acum,
@@ -71,8 +72,9 @@ const formatProperties = (properties, options = {}) => {
         ...combineSchema(elements),
         ...addTypeApplication(applications, propertyExpression),
         ...addRefSchema(typeName, applications, elements),
-        ...(format ? { format } : {}),
+        ...(format && !clientValues ? { format } : {}),
         ...addEnumValues(enumValues),
+        ...addClientValues(clientValues),
 
         // Add nullable to non-required fields if option to do that is enabled
         ...(options.notRequiredAsNullable && !isRequired ? {
@@ -112,13 +114,20 @@ const parseSchema = (schema, options = {}) => {
   const typedef = getTagInfo(schema.tags, 'typedef');
   const propertyValues = getTagsInfo(schema.tags, 'property');
   const requiredProperties = getRequiredProperties(propertyValues);
-  const [descriptionValue, enumValues, jsonOptions] = formatDescription(schema.description);
+  const [descriptionValue, enumValues, clientValues, jsonOptions] = formatDescription(schema.description);
   const [description, format] = mapDescription(descriptionValue);
+  if (clientValues !== undefined) {
+    console.error(`TODO: add support for clients: ${JSON.stringify(clientValues)}; tell aimee if you see this error`);
+  }
   if (!typedef || !typedef.name) return {};
   const {
     elements,
   } = typedef.type;
   const type = typedef.type.name || 'object';
+  let formattedProperties = formatProperties(propertyValues, options);
+  if (options.client && hasClientProperty(formattedProperties)) {
+    formattedProperties = removePropertyByClient(formattedProperties, options.client);
+  }
   return {
     [typedef.name]: {
       ...combineSchema(elements),
@@ -128,7 +137,7 @@ const parseSchema = (schema, options = {}) => {
       } : {}),
       type,
       ...(type === 'object' ? {
-        properties: formatProperties(propertyValues, options),
+        properties: formattedProperties,
       } : {}),
       ...(format ? { format } : {}),
       ...addEnumValues(enumValues),

--- a/transforms/paths/parameters.js
+++ b/transforms/paths/parameters.js
@@ -59,7 +59,7 @@ const parseParameter = param => {
   const isDeprecated = extraOptions.includes(DEPRECATED);
   const shouldExplode = extraOptions.includes(EXPLODE);
   const shouldNotExplode = extraOptions.includes(NOEXPLODE);
-  const [description, enumValues, jsonOptions] = formatDescription(param.description);
+  const [description, enumValues, clientOptions, jsonOptions] = formatDescription(param.description);
   const options = {
     name,
     in: inOption,

--- a/transforms/utils/clientPropertyMethods.js
+++ b/transforms/utils/clientPropertyMethods.js
@@ -1,0 +1,52 @@
+const addClientValues = (values = []) => {
+  if (values.length === 0) return {};
+  return { clients: values };
+};
+
+function hasClientProperty(clientObj) {
+  function search(obj) {
+    if (obj && typeof obj === 'object') {
+      if ('clients' in obj) {
+        return true;
+      }
+      return Object.values(obj).some(value => search(value));
+    }
+    return false;
+  }
+  return search(clientObj);
+}
+
+function removePropertyByClient(clientObj, clientName) {
+  function process(obj) {
+    if (obj && typeof obj === 'object' && !Array.isArray(obj)) {
+      // Go through every key in the object
+      return Object.entries(obj).reduce((result, [key, value]) => {
+        const response = { ...result };
+        // Check if the current value is an object with a 'clients' key
+        if (value && typeof value === 'object' && 'clients' in value) {
+          // Keep the entry only if the clientName is in the 'clients' array
+          if (value.clients.includes(clientName)) {
+            // Delete the clients parameter after use so it doesn't show up in the schema
+            const valueWithoutClients = { ...value };
+            delete valueWithoutClients.clients;
+            response[key] = process(valueWithoutClients); // Recursively process nested objects
+          }
+        } else {
+          // Recursively process nested objects and keep non-clients entries
+          response[key] = process(value);
+        }
+        return response;
+      }, {});
+    }
+    // Return non-object values as-is
+    return obj;
+  }
+
+  return process(clientObj);
+}
+
+module.exports = {
+  addClientValues,
+  removePropertyByClient,
+  hasClientProperty,
+};

--- a/transforms/utils/formatDescription.js
+++ b/transforms/utils/formatDescription.js
@@ -2,6 +2,7 @@ const mapDescription = require('./mapDescription');
 const errorMessage = require('./errorMessage');
 
 const ENUM_IDENTIFIER = 'enum:';
+const CLIENTS_IDENTIFIER = 'clients:';
 const JSON_IDENTIFIER = 'json:';
 const DESCRIPTION_DIVIDER = ' - ';
 
@@ -12,11 +13,19 @@ const formatDescription = description => {
   )).join(DESCRIPTION_DIVIDER);
   const enumOption = descriptionTypes.find(value => value.includes(ENUM_IDENTIFIER));
   const jsonOption = descriptionTypes.find(value => value.includes(JSON_IDENTIFIER));
+  const clientsOption = descriptionTypes.find(value => value.includes(CLIENTS_IDENTIFIER));
   const res = [descriptionValue];
   if (enumOption) {
     const [, enumOptions] = enumOption.split('enum:');
     const enumValues = enumOptions.split(',');
     res.push(enumValues);
+  } else {
+    res.push(undefined);
+  }
+  if (clientsOption) {
+    const [, clientsOptions] = clientsOption.split('clients:');
+    const clientValues = clientsOptions.split(',');
+    res.push(clientValues);
   } else {
     res.push(undefined);
   }


### PR DESCRIPTION
### What kind of change does this PR introduce? (check at least one)
 - [ ] Bugfix
 - [X] Feature
 - [X] Test
 - [ ] Docs
 - [ ] Refactor
 - [ ] Build-related changes
 - [ ] Other, please describe:

### Description:
- allows a property to be client specific using clients:internal,hecof

![image](https://github.com/user-attachments/assets/9f868491-c8a7-4d5c-b216-5fde94a8686c)
![image](https://github.com/user-attachments/assets/b97f128b-b7d6-4efa-af7f-741f3be479fa)
![image](https://github.com/user-attachments/assets/c6695c4d-eb9b-4c07-97ea-e033d23182d4)
