### PR TITLE
ADDED | support for jsdoc with urls as keys

### DIFF
--- a/consumers/utils/parseComments.js
+++ b/consumers/utils/parseComments.js
@@ -1,0 +1,25 @@
+const parseCommentWithUrlPropsAsKeys = comment => {
+  const typedefMatch = comment.match(/}}\s*([\w]+)/);
+  const typedefName = typedefMatch ? typedefMatch[1] : 'UnknownType';
+  const res = comment.replace(/@typedef\s+\{\{\[/, '@typedef {{\n * [') // add a newline between typedef and first property
+    .replace(/\/\/\s+/gm, '-') // Remove any instances of comments which are used to make linting work
+    .replace(/--/g, '-') // Remove double hyphen if exists
+    .replace(/@typedef\s+\{\{/, `@typedef {object} ${typedefName}`) // Convert to standard typedef
+    .replace(/}}\s*[\w]+/, '') // Remove old typedef name
+    .replace(/https:\/\//g, 'https')
+    // .replace(/\['([^']+)'\]:\s*([^,}\n]+)([^}]*),?/g, '@property {$2} $1$3')
+    .replace(/\[\s*'([^']+)'\s*\]\s*:\s*([^-\n]+)\s*-\s*(.*)/g, // property with description
+      (_match, prop, type, desc) => `@property {${type.replace(',', '').trim()}} ${prop} - ${desc.trim()}`)
+    .replace(/\[\s*'([^']+)'\s*\]\s*\?:\s*([^-\n]+)\s*-\s*(.*)/g, // property with description and is optional
+      (_match, prop, type, desc) => `@property {${type.replace(',', '').trim()}=} ${prop} - ${desc.trim()}`)
+    .replace(/\[\s*'([^']+)'\s*\]\s*:\s*([^-\n]+)/g, // property without description
+      (_match, prop, type) => `@property {${type.replace(',', '').trim()}} ${prop}`)
+    .replace(/\[\s*'([^']+)'\s*\]\s*\?:\s*([^-\n]+)/g, // property without description and is optional
+      (_match, prop, type) => `@property {${type.replace(',', '').trim()}=} ${prop}`)
+    .replace(/,\s*$/gm, ''); // remove commas at end of line
+  return res;
+};
+
+module.exports = {
+  parseCommentWithUrlPropsAsKeys,
+};

--- a/test/consumers/parseComments/index.test.js
+++ b/test/consumers/parseComments/index.test.js
@@ -1,0 +1,25 @@
+const { parseCommentWithUrlPropsAsKeys } = require('../../../consumers/utils/parseComments');
+
+describe('parsing comments', () => {
+  it('should convert the linting supported jsdoc with url keys into a structure jsdoc can interpret', () => {
+    const comment = `
+      /**
+       * Learner Profile Global Extensions model
+       * @typedef {{['https://api.adaptemy.io/param-a']: number, // - some description - clients:internal,bbc,
+       * ['https://api.adaptemy.io/param-b']: number,
+       * ['https://api.adaptemy.io/param-c']?: string // - some description}} LearnerProfileGlobalExtensions
+       */
+    `;
+    const expected = `
+      /**
+       * Learner Profile Global Extensions model
+       * @typedef {object} LearnerProfileGlobalExtensions
+ * @property {number} httpsapi.adaptemy.io/param-a - some description - clients:internal,bbc
+       * @property {number} httpsapi.adaptemy.io/param-b
+       * @property {string=} httpsapi.adaptemy.io/param-c - some description
+       */
+    `;
+    const result = parseCommentWithUrlPropsAsKeys(comment);
+    expect(result).toEqual(expected);
+  });
+});

--- a/test/transforms/components/index.test.js
+++ b/test/transforms/components/index.test.js
@@ -290,45 +290,37 @@ describe('parseComponents method', () => {
     expect(result).toEqual(expected);
   });
 
-  // TODO: add the functionality to make this test pass
-  // eslint-disable-next-line jest/no-disabled-tests
-  it.skip('Should parse jsdoc component spec with non-standard property name', () => {
+  it('Should parse jsdoc component spec with non-standard property name', () => {
     const jsodInput = [`
       /**
-       * A song
-       * @typedef {object} Song
-       * @property {{'en-US': string - Some description US, 'en-UK': string - Some description UK}}
-       * @property {string=} artist - The artist - json:{"maxLength": 300}
-       * @property {number=} year - The year - int64 - json:{"minimum": 2000}
+       * Learner Profile Global Extensions model
+       * @typedef {{['https://api.adaptemy.io/param-a']: number, // - some description - clients:internal,bbc,
+       * ['https://api.adaptemy.io/param-b']: number,
+       * ['https://api.adaptemy.io/param-c']?: string // some description}} LearnerProfileGlobalExtensions
        */
     `];
     const expected = {
       components: {
         schemas: {
-          Song: {
+          LearnerProfileGlobalExtensions: {
             type: 'object',
-            description: 'A song',
+            description: 'Learner Profile Global Extensions model',
             properties: {
-              'en-US': {
-                type: 'string',
-                description: 'Some description US',
-              },
-              'en-UK': {
-                type: 'string',
-                description: 'Some description UK',
-              },
-              artist: {
-                type: 'string',
-                description: 'The artist',
-                maxLength: 300,
-              },
-              year: {
+              'https://api.adaptemy.io/param-a': {
+                clients: ['internal', 'bbc'],
+                description: 'some description',
                 type: 'number',
-                description: 'The year',
-                format: 'int64',
-                minimum: 2000,
+              },
+              'https://api.adaptemy.io/param-b': {
+                description: '',
+                type: 'number',
+              },
+              'https://api.adaptemy.io/param-c': {
+                type: 'string',
+                description: 'some description',
               },
             },
+            required: ['https://api.adaptemy.io/param-a', 'https://api.adaptemy.io/param-b'],
           },
         },
       },

--- a/transforms/components/index.js
+++ b/transforms/components/index.js
@@ -10,6 +10,9 @@ const validateTypes = require('../utils/validateTypes');
 const REQUIRED = 'required';
 
 const getPropertyName = ({ name: propertyName }) => {
+  if (propertyName.startsWith('https')) {
+    return propertyName;
+  }
   const [name] = propertyName.split('.');
   return name;
 };


### PR DESCRIPTION
### What kind of change does this PR introduce? (check at least one)
 - [ ] Bugfix
 - [X] Feature
 - [X] Test
 - [ ] Docs
 - [ ] Refactor
 - [ ] Build-related changes
 - [ ] Other, please describe:

### Description:
- add support for jsdoc with urls as keys
- which also allows descriptions and client specifiers

![image](https://github.com/user-attachments/assets/0cdf377b-7e27-420a-b1d9-9aec99425dc6)

![image](https://github.com/user-attachments/assets/2d7cf6a8-8233-40d4-974a-c0b3d6d3deca)
